### PR TITLE
fix: add missing tool logos to skills section

### DIFF
--- a/Assets/icons/bash.svg
+++ b/Assets/icons/bash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="15" fill="#1D1D1D"/>
+  <text x="10" y="90" font-family="monospace" font-size="68" font-weight="bold" fill="#3FB950">$_</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -194,19 +194,23 @@
                         <img src="Assets/icons/python.svg" alt="Python" class="tech-icon">
                         <span class="tech-name">Python</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg" alt="TypeScript" class="tech-icon">
                         <span class="tech-name">TypeScript</span>
                     </div>
                     <div class="tech-item tech-item-text">
                         <span class="tech-name">SQL</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="Assets/icons/bash.svg" alt="Bash" class="tech-icon">
                         <span class="tech-name">Bash</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/c/c-original.svg" alt="C" class="tech-icon">
                         <span class="tech-name">C</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/php/php-original.svg" alt="PHP" class="tech-icon">
                         <span class="tech-name">PHP</span>
                     </div>
                     <div class="cert-actions">
@@ -222,13 +226,16 @@
                         <img src="Assets/icons/spring.svg" alt="Spring Boot" class="tech-icon">
                         <span class="tech-name">Spring Boot</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="Assets/icons/spring.svg" alt="Spring MVC" class="tech-icon">
                         <span class="tech-name">Spring MVC</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="Assets/icons/spring.svg" alt="Spring Security" class="tech-icon">
                         <span class="tech-name">Spring Security</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/hibernate/hibernate-original.svg" alt="Hibernate/JPA" class="tech-icon">
                         <span class="tech-name">Hibernate/JPA</span>
                     </div>
                     <div class="tech-item tech-item-text">
@@ -252,13 +259,16 @@
                         <img src="Assets/icons/github.svg" alt="GitHub" class="tech-icon">
                         <span class="tech-name">GitHub</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/postgresql/postgresql-original.svg" alt="PostgreSQL" class="tech-icon">
                         <span class="tech-name">PostgreSQL</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/maven/maven-original.svg" alt="Maven" class="tech-icon">
                         <span class="tech-name">Maven</span>
                     </div>
-                    <div class="tech-item tech-item-text">
+                    <div class="tech-item">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/linux/linux-original.svg" alt="Linux" class="tech-icon">
                         <span class="tech-name">Linux</span>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #5

Adds icons to tech items in the skills section that previously had no logos. Uses devicons CDN for TypeScript, C, PHP, Hibernate/JPA, PostgreSQL, Maven, and Linux. Creates a custom terminal-style SVG for Bash. Reuses the existing spring.svg for Spring MVC and Spring Security.

Generated with [Claude Code](https://claude.ai/code)